### PR TITLE
ENG-9236 Refresh xebialabs/tiny-tools image version or replace it

### DIFF
--- a/release-operator-aws-eks/digitalai-release/kubernetes/template/deployment.yaml
+++ b/release-operator-aws-eks/digitalai-release/kubernetes/template/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=xlr-operator-controller-manager
-        image: xebialabsunsupported/release-operator:22.2.0-314.113
+        image: xebialabsunsupported/release-operator:22.2.0-318.955
         livenessProbe:
           httpGet:
             path: /readyz

--- a/release-operator-azure-aks/digitalai-release/kubernetes/template/deployment.yaml
+++ b/release-operator-azure-aks/digitalai-release/kubernetes/template/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=xlr-operator-controller-manager
-        image: xebialabsunsupported/release-operator:22.2.0-314.113
+        image: xebialabsunsupported/release-operator:22.2.0-318.955
         livenessProbe:
           httpGet:
             path: /readyz

--- a/release-operator-gcp-gke/digitalai-release/kubernetes/template/deployment.yaml
+++ b/release-operator-gcp-gke/digitalai-release/kubernetes/template/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=xlr-operator-controller-manager
-        image: xebialabsunsupported/release-operator:22.2.0-314.113
+        image: xebialabsunsupported/release-operator:22.2.0-318.955
         livenessProbe:
           httpGet:
             path: /readyz

--- a/release-operator-onprem/digitalai-release/kubernetes/template/deployment.yaml
+++ b/release-operator-onprem/digitalai-release/kubernetes/template/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=xlr-operator-controller-manager
-        image: xebialabsunsupported/release-operator:22.2.0-314.113
+        image: xebialabsunsupported/release-operator:22.2.0-318.955
         livenessProbe:
           httpGet:
             path: /readyz

--- a/release-operator-openshift/digitalai-release/kubernetes/template/deployment.yaml
+++ b/release-operator-openshift/digitalai-release/kubernetes/template/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --leader-election-id=xlr-operator-controller-manager
-        image: xebialabsunsupported/release-operator:22.2.0-314.113-openshift
+        image: xebialabsunsupported/release-operator:22.2.0-openshift
         livenessProbe:
           httpGet:
             path: /readyz


### PR DESCRIPTION
https://digitalai.atlassian.net/browse/ENG-9236

The operators were using an old release-operator images that didn't have support for TinyToolsImageRepository and TinyToolsImageTag parameters.

I've built the images, published them to xebialabsunsupported and updated their tags in deployment.yaml files.